### PR TITLE
feat: improve gemspec and fix RuboCop warnings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,20 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 9
-# Configuration parameters: EnforcedStyle, AllowedGems.
-# SupportedStyles: Gemfile, gems.rb, gemspec
-Gemspec/DevelopmentDependencies:
-  Exclude:
-    - 'prawn-rtl-support.gemspec'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Severity.
-Gemspec/RequireMFA:
-  Exclude:
-    - 'prawn-rtl-support.gemspec'
-
 # Offense count: 2
 Lint/IneffectiveAccessModifier:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,16 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in prawn-rtl-support.gemspec
 gemspec
+
+# Development dependencies
+group :development, :test do
+  gem 'pry', '~> 0.12'
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.9'
+  gem 'rubocop', '1.80.2'
+  gem 'rubocop-performance', '1.25.0'
+  gem 'rubocop-rake', '0.7.1'
+  gem 'rubocop-rspec', '3.7.0'
+  gem 'rubocop-rubycw', '0.2.2'
+  gem 'rubocop-thread_safety', '0.7.3'
+end

--- a/prawn-rtl-support.gemspec
+++ b/prawn-rtl-support.gemspec
@@ -16,22 +16,14 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = '>= 2.7.0'
 
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'pry', '~> 0.12'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'rubocop', '1.80.2'
-  spec.add_development_dependency 'rubocop-performance', '1.25.0'
-  spec.add_development_dependency 'rubocop-rake', '0.7.1'
-  spec.add_development_dependency 'rubocop-rspec', '3.7.0'
-  spec.add_development_dependency 'rubocop-rubycw', '0.2.2'
-  spec.add_development_dependency 'rubocop-thread_safety', '0.7.3'
 
   spec.add_dependency 'prawn', '~> 2.2'
   spec.add_dependency 'twitter_cldr', '>= 4.0', '< 7.0'


### PR DESCRIPTION
- Add required Ruby version (>= 2.7.0) to gemspec
- Add rubygems_mfa_required metadata for security
- Move development dependencies from gemspec to Gemfile
- Update RuboCop TODO to reflect fixed violations